### PR TITLE
Update Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Scrapy==2.7.1
+Scrapy==2.11.2
 pylint==2.15.8
-redis==4.4.0
-requests==2.28.1
+redis==5.0.6
+requests==2.32.3


### PR DESCRIPTION
Bump redis from 4.4.0 to 5.0.6

Bumps [redis](https://github.com/redis/redis-py) from 4.4.0 to 4.4.4.
- [Release notes](https://github.com/redis/redis-py/releases)
- [Changelog](https://github.com/redis/redis-py/blob/master/CHANGES)
- [Commits](https://github.com/redis/redis-py/compare/v4.4.0...v4.4.4)

---
updated-dependencies:
- dependency-name: redis dependency-type: direct:production ...



Bump requests from 2.28.1 to 2.32.3

Bumps [requests](https://github.com/psf/requests) from 2.28.1 to 2.32.2.
- [Release notes](https://github.com/psf/requests/releases)
- [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md)
- [Commits](https://github.com/psf/requests/compare/v2.28.1...v2.32.2)

---
updated-dependencies:
- dependency-name: requests dependency-type: direct:production ...



Bump scrapy from 2.7.1 to 2.11.2

Bumps [scrapy](https://github.com/scrapy/scrapy) from 2.7.1 to 2.11.2.
- [Release notes](https://github.com/scrapy/scrapy/releases)
- [Changelog](https://github.com/scrapy/scrapy/blob/master/docs/news.rst)
- [Commits](https://github.com/scrapy/scrapy/compare/2.7.1...2.11.2)

---
updated-dependencies:
- dependency-name: scrapy dependency-type: direct:production ...